### PR TITLE
Load Firebase config from env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,7 +73,7 @@ web_modules/
 .yarn-integrity
 
 # dotenv environment variable files
-.env
+/.env
 .env.development.local
 .env.test.local
 .env.production.local

--- a/README.md
+++ b/README.md
@@ -15,3 +15,19 @@ By default, Replit runs the `dev` script, but you can configure it by changing t
 ### Typescript
 
 Just rename any file from `.jsx` to `.tsx`. You can also try our [TypeScript Template](https://replit.com/@replit/React-TypeScript)
+
+### Environment Variables
+
+Create a `.env` file in the project root and define your Firebase settings:
+
+```
+VITE_FIREBASE_API_KEY=<your api key>
+VITE_FIREBASE_AUTH_DOMAIN=<your auth domain>
+VITE_FIREBASE_PROJECT_ID=<your project id>
+VITE_FIREBASE_STORAGE_BUCKET=<your storage bucket>
+VITE_FIREBASE_MESSAGING_SENDER_ID=<your sender id>
+VITE_FIREBASE_APP_ID=<your app id>
+```
+
+These values are loaded in `src/App.jsx` via `import.meta.env`.
+

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,14 +13,14 @@ import {
   onAuthStateChanged 
 } from 'firebase/auth';
 
-// Firebase configuration - Replace with your actual config
+// Firebase configuration pulled from environment variables
 const firebaseConfig = {
-  apiKey: "AIzaSyANv-NM_A5ZXB-FReeMLFveD_dQSnU3iYA",
-  authDomain: "brim-7c24b.firebaseapp.com",
-  projectId: "brim-7c24b",
-  storageBucket: "brim-7c24b.appspot.com",
-  messagingSenderId: "93916627211",
-  appId: "1:93916627211:web:8179df32b94e20402fa20e"
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+  appId: import.meta.env.VITE_FIREBASE_APP_ID
 };
 
 // Initialize Firebase


### PR DESCRIPTION
## Summary
- reference Firebase settings from `import.meta.env`
- ignore root `.env`
- document expected `.env` variables

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859a61c5168832bb80763cbba3f81bc